### PR TITLE
[strands_movebase] Decreased the cost_scaling_factor

### DIFF
--- a/strands_movebase/strands_movebase_params/costmap_common_params.yaml
+++ b/strands_movebase/strands_movebase_params/costmap_common_params.yaml
@@ -17,7 +17,7 @@ no_go_layer:
 
 inflation_layer:
   inflation_radius: 0.8
-  cost_scaling_factor: 10.0
+  cost_scaling_factor: 5.0
     
 
 obstacle_layer:


### PR DESCRIPTION
This makes the robot stay further away from walls if possible. This made navigation more robust on Rosie, particularly through doors where we had a problem of running into the doorway sometimes.
