### PR TITLE
[strands_movebase] Add option to use head_camera as well

### DIFF
--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -42,8 +42,7 @@
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->
     <node pkg="strands_movebase" type="remove_edges_cloud" name="head_remove_edges_cloud" output="screen" if="$(arg with_head_camera)">
-        <!-- <param name="input" value="/move_base/head_points_clearing"/> -->
-        <param name="input" value="/head_xtion/depth/points"/>
+        <param name="input" value="/move_base/head_points_clearing"/>
         <param name="output" value="/move_base/head_points_obstacle"/>
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>
@@ -68,7 +67,6 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load" />
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor</rosparam>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
 	</node>
@@ -87,7 +85,6 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load" />
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor</rosparam>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
 	</node>

--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -42,7 +42,8 @@
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->
     <node pkg="strands_movebase" type="remove_edges_cloud" name="head_remove_edges_cloud" output="screen" if="$(arg with_head_camera)">
-        <param name="input" value="/move_base/head_points_clearing"/>
+        <!-- <param name="input" value="/move_base/head_points_clearing"/> -->
+        <param name="input" value="/head_xtion/depth/points"/>
         <param name="output" value="/move_base/head_points_obstacle"/>
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>
@@ -67,8 +68,8 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load" />
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor]</rosparam>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor, head_cloud_sensor, head_clear_sensor]</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
 	</node>
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" clear_params="true" unless="$(arg with_mux)">
@@ -86,8 +87,8 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load" />
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor]</rosparam>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor, head_cloud_sensor, head_clear_sensor]</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
 	</node>
 

--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -31,14 +31,6 @@
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>
     </node>
-    
-    <!-- This node downsamples cloud and removes voxels with too few points in them -->
-    <!--
-    <node pkg="strands_movebase" type="subsample_cloud" name="head_subsample_cloud" output="screen" if="$(arg with_head_camera)">
-        <param name="input" value="$(arg head_camera)/depth/points"/>
-        <param name="output" value="/move_base/head_points_clearing"/>
-    </node>
-    -->
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->
     <node pkg="strands_movebase" type="remove_edges_cloud" name="head_remove_edges_cloud" output="screen" if="$(arg with_head_camera)">

--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -61,6 +61,7 @@
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
+        <param name="local_costmap/obstacle_layer/unknown_threshold" value="9" if="$(arg with_head_camera)"/>
 	</node>
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" clear_params="true" unless="$(arg with_mux)">
         <!-- default:20.0. with this value dwa planner fails to find a valid plan a lot more -->
@@ -79,6 +80,7 @@
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
+        <param name="local_costmap/obstacle_layer/unknown_threshold" value="9" if="$(arg with_head_camera)"/>
 	</node>
 
 </launch>

--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -6,7 +6,6 @@
 	<arg name="z_stair_threshold" default="0.05"/>
 	<arg name="z_obstacle_threshold" default="0.1"/>
 	<arg name="with_head_camera" default="false"/>
-	<arg name="head_camera" default="head_xtion"/>
 
 	<machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)" default="true"/>
 
@@ -34,10 +33,12 @@
     </node>
     
     <!-- This node downsamples cloud and removes voxels with too few points in them -->
+    <!--
     <node pkg="strands_movebase" type="subsample_cloud" name="head_subsample_cloud" output="screen" if="$(arg with_head_camera)">
         <param name="input" value="$(arg head_camera)/depth/points"/>
         <param name="output" value="/move_base/head_points_clearing"/>
     </node>
+    -->
 
     <!-- This node removes the desired cutoff pixels from the cloud edges -->
     <node pkg="strands_movebase" type="remove_edges_cloud" name="head_remove_edges_cloud" output="screen" if="$(arg with_head_camera)">

--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -5,6 +5,8 @@
 	<arg name="with_mux" default="false" />
 	<arg name="z_stair_threshold" default="0.05"/>
 	<arg name="z_obstacle_threshold" default="0.1"/>
+	<arg name="with_head_camera" default="false"/>
+	<arg name="head_camera" default="head_xtion"/>
 
 	<machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)" default="true"/>
 
@@ -31,6 +33,20 @@
         <param name="cutoff_z" value="0.3"/>
     </node>
     
+    <!-- This node downsamples cloud and removes voxels with too few points in them -->
+    <node pkg="strands_movebase" type="subsample_cloud" name="head_subsample_cloud" output="screen" if="$(arg with_head_camera)">
+        <param name="input" value="$(arg head_camera)/depth/points"/>
+        <param name="output" value="/move_base/head_points_clearing"/>
+    </node>
+
+    <!-- This node removes the desired cutoff pixels from the cloud edges -->
+    <node pkg="strands_movebase" type="remove_edges_cloud" name="head_remove_edges_cloud" output="screen" if="$(arg with_head_camera)">
+        <param name="input" value="/move_base/head_points_clearing"/>
+        <param name="output" value="/move_base/head_points_obstacle"/>
+        <param name="cutoff" value="50.0"/>
+        <param name="cutoff_z" value="0.3"/>
+    </node>
+    
     <!-- This node enables us to visualize the 3d occupancy of the costmap -->
 	<node pkg="costmap_2d" type="costmap_2d_cloud" name="costmap_2d_cloud" output="screen"/>
 
@@ -50,6 +66,8 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load" />
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor]</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor, head_cloud_sensor, head_clear_sensor]</rosparam>
 	</node>
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" clear_params="true" unless="$(arg with_mux)">
         <!-- default:20.0. with this value dwa planner fails to find a valid plan a lot more -->
@@ -66,6 +84,8 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load" />
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor]</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor, head_cloud_sensor, head_clear_sensor]</rosparam>
 	</node>
 
 </launch>

--- a/strands_movebase/launch/config.launch
+++ b/strands_movebase/launch/config.launch
@@ -68,6 +68,7 @@
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor]</rosparam>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor, head_cloud_sensor, head_clear_sensor]</rosparam>
+        <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
 	</node>
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen" clear_params="true" unless="$(arg with_mux)">
         <!-- default:20.0. with this value dwa planner fails to find a valid plan a lot more -->
@@ -86,6 +87,7 @@
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" unless="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor]</rosparam>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_camera)">[laser, point_cloud_sensor, clear_sensor, cliff_sensor, head_cloud_sensor, head_clear_sensor]</rosparam>
+        <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_camera)"/>
 	</node>
 
 </launch>

--- a/strands_movebase/launch/movebase.launch
+++ b/strands_movebase/launch/movebase.launch
@@ -42,7 +42,7 @@
 		<arg name="with_mux" value="$(arg with_mux)"/>
 		<arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
 		<arg name="z_obstacle_threshold" value="$(arg z_obstacle_threshold)"/>
-		<arg mame="with_head_camera" value="$(arg with_head_camera)"/>
+		<arg name="with_head_camera" value="$(arg with_head_camera)"/>
     </include>
     <include file="$(find scitos_2d_navigation)/launch/move_base.launch" unless="$(arg with_camera)">
         <arg name="machine"  value="$(arg machine)"/>

--- a/strands_movebase/launch/movebase.launch
+++ b/strands_movebase/launch/movebase.launch
@@ -10,6 +10,8 @@
     <arg name="no_go_map"/>
     <arg name="z_stair_threshold" default="0.05"/>
     <arg name="z_obstacle_threshold" default="0.1"/>
+    <arg name="with_head_camera" default="false"/>
+    <arg name="head_camera" default="head_xtion"/>
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)" default="true"/>
 
@@ -41,6 +43,8 @@
 		<arg name="with_mux" value="$(arg with_mux)"/>
 		<arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
 		<arg name="z_obstacle_threshold" value="$(arg z_obstacle_threshold)"/>
+		<arg mame="with_head_camera" value="$(arg with_head_camera)"/>
+		<arg name="head_camera" value="$(arg head_camera)"/>
     </include>
     <include file="$(find scitos_2d_navigation)/launch/move_base.launch" unless="$(arg with_camera)">
         <arg name="machine"  value="$(arg machine)"/>

--- a/strands_movebase/launch/movebase.launch
+++ b/strands_movebase/launch/movebase.launch
@@ -11,7 +11,6 @@
     <arg name="z_stair_threshold" default="0.05"/>
     <arg name="z_obstacle_threshold" default="0.1"/>
     <arg name="with_head_camera" default="false"/>
-    <arg name="head_camera" default="head_xtion"/>
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)" default="true"/>
 
@@ -44,7 +43,6 @@
 		<arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
 		<arg name="z_obstacle_threshold" value="$(arg z_obstacle_threshold)"/>
 		<arg mame="with_head_camera" value="$(arg with_head_camera)"/>
-		<arg name="head_camera" value="$(arg head_camera)"/>
     </include>
     <include file="$(find scitos_2d_navigation)/launch/move_base.launch" unless="$(arg with_camera)">
         <arg name="machine"  value="$(arg machine)"/>

--- a/strands_movebase/src/remove_edges_cloud.cpp
+++ b/strands_movebase/src/remove_edges_cloud.cpp
@@ -46,34 +46,35 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "remove_edges_cloud");
 	ros::NodeHandle n;	
 
+    ros::NodeHandle pn("~");
     // topic of input cloud
-    if (!n.hasParam("/remove_edges_cloud/input")) {
+    if (!pn.hasParam("input")) {
         ROS_ERROR("Could not find parameter input.");
         return -1;
     }
     std::string input;
-    n.getParam("/remove_edges_cloud/input", input);
+    pn.getParam("input", input);
     
     // topic of output cloud
-    if (!n.hasParam("/remove_edges_cloud/output")) {
+    if (!pn.hasParam("output")) {
         ROS_ERROR("Could not find parameter output.");
         return -1;
     }
     std::string output;
-    n.getParam("/remove_edges_cloud/output", output);
+    pn.getParam("output", output);
 
     // how many pixels to cut off in the depth image
-	if (!n.hasParam("/remove_edges_cloud/cutoff")) {
+	if (!pn.hasParam("cutoff")) {
         ROS_ERROR("Could not find parameter cutoff.");
         return -1;
     }
-    n.getParam("/remove_edges_cloud/cutoff", cutoff);
+    pn.getParam("cutoff", cutoff);
     
-    if (!n.hasParam("/remove_edges_cloud/cutoff_z")) {
+    if (!pn.hasParam("cutoff_z")) {
         ROS_ERROR("Could not find parameter cutoff_z.");
         return -1;
     }
-    n.getParam("/remove_edges_cloud/cutoff_z", cutoff_z);
+    pn.getParam("cutoff_z", cutoff_z);
     
 	ros::Subscriber sub = n.subscribe(input, 1, callback);
     pub = n.advertise<sensor_msgs::PointCloud2>(output, 1);

--- a/strands_movebase/src/subsample_cloud.cpp
+++ b/strands_movebase/src/subsample_cloud.cpp
@@ -38,21 +38,22 @@ int main(int argc, char** argv)
     ros::init(argc, argv, "subsample_cloud");
 	ros::NodeHandle n;
 	
+	ros::NodeHandle pn("~");
     // topic of input cloud
-    if (!n.hasParam("/subsample_cloud/input")) {
+    if (!pn.hasParam("input")) {
         ROS_ERROR("Could not find parameter input.");
         return -1;
     }
     std::string input;
-    n.getParam("/subsample_cloud/input", input);
+    pn.getParam("input", input);
     
     // topic of output cloud
-    if (!n.hasParam("/subsample_cloud/output")) {
+    if (!pn.hasParam("output")) {
         ROS_ERROR("Could not find parameter output.");
         return -1;
     }
     std::string output;
-    n.getParam("/subsample_cloud/output", output);
+    pn.getParam("output", output);
     
 	ros::Subscriber sub = n.subscribe(input, 1, callback);
     pub = n.advertise<sensor_msgs::PointCloud2>(output, 1);

--- a/strands_movebase/strands_movebase_params/costmap_common_params.yaml
+++ b/strands_movebase/strands_movebase_params/costmap_common_params.yaml
@@ -43,4 +43,4 @@ obstacle_layer:
 
   head_cloud_sensor: {topic: /move_base/head_points_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
   
-  head_clear_sensor: {topic: /move_base/head_points_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
+  head_clear_sensor: {topic: /head_xtion/depth/points, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}

--- a/strands_movebase/strands_movebase_params/costmap_common_params.yaml
+++ b/strands_movebase/strands_movebase_params/costmap_common_params.yaml
@@ -41,15 +41,6 @@ obstacle_layer:
   
   cliff_sensor: {topic: /move_base/points_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
 
-  wall_cloud: {topic: /move_base/clear_wall, sensor_frame: /chest_xtion_depth_optical_frame, data_type: PointCloud2, marking: false, clearing: true, observation_persistence: 0.0, raytrace_range: 2.80}
-
-
-
+  head_cloud_sensor: {topic: /move_base/head_points_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
   
-
-
-  
-#point_cloud_sensor: {sensor_frame: camera_link, data_type: PointCloud2, topic: /camera/depth/points, marking: true, clearing: true}
-
-
-
+  head_clear_sensor: {topic: /move_base/head_points_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}

--- a/strands_movebase/strands_movebase_params/costmap_common_params.yaml
+++ b/strands_movebase/strands_movebase_params/costmap_common_params.yaml
@@ -41,6 +41,6 @@ obstacle_layer:
   
   cliff_sensor: {topic: /move_base/points_cliff, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.15, observation_persistence: 0.0, obstacle_range: 3.0}
 
-  head_cloud_sensor: {topic: /move_base/head_points_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
+  head_cloud_sensor: {topic: /move_base/head_points_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.3, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 3.0}
   
-  head_clear_sensor: {topic: /head_xtion/depth/points, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.1, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 4.0}
+  head_clear_sensor: {topic: /move_base/head_points_clearing, data_type: PointCloud2, marking: false, clearing: true, min_obstacle_height: -0.2, max_obstacle_height: 1.1, observation_persistence: 0.0, raytrace_range: 5.0}


### PR DESCRIPTION
This adds the parameter `with_head_camera:=<bool>` to `movebase.launch`. If enabled, it will make the obstacle voxel grid higher to account for the head camera and listen to points on topic `/move_base/head_points_clearing` as published by `backtrack.launch` in `backtrack_behaviour` package. If you want to use the `backtrack_behaviour` recovery behaviour, you have to set `with_head_camera:=true` when launching `movebase.launch`.

This also fixes private namespace parameters for all the nodes in this package since that is needed when using multiple nodes of the same type.
