### PR TITLE
[strands_movebase] Removed global costmap voxelgrid publishing

### DIFF
--- a/strands_movebase/launch/movebase.launch
+++ b/strands_movebase/launch/movebase.launch
@@ -72,6 +72,7 @@
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_xtion)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
+        <param name="local_costmap/obstacle_layer/publish_voxel_map" value="true"/>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_xtion)"/>
         <param name="local_costmap/obstacle_layer/unknown_threshold" value="9" if="$(arg with_head_xtion)"/>
         <!-- THIS SHOULD STAY LAST, so that sites can override anything. -->

--- a/strands_movebase/strands_movebase_params/costmap_common_params.yaml
+++ b/strands_movebase/strands_movebase_params/costmap_common_params.yaml
@@ -27,7 +27,6 @@ inflation_layer:
   cost_scaling_factor: 5.0
 
 obstacle_layer:
-  publish_voxel_map: true
   max_obstacle_height: 2.0
   obstacle_range: 2.5
   raytrace_range: 3.0


### PR DESCRIPTION
Made the voxel map publish only for the local costmap as it might be demanding to publish the global
