### PR TITLE
[strands_movebase] Don't add obstacles at edge of laser's FOV

### DIFF
--- a/strands_movebase/CMakeLists.txt
+++ b/strands_movebase/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(mirror_floor_points
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS subsample_cloud remove_edges_cloud mirror_floor_points noise_approximate_voxel_grid
+install(TARGETS subsample_cloud remove_edges_cloud remove_edges_laser mirror_floor_points noise_approximate_voxel_grid
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/strands_movebase/CMakeLists.txt
+++ b/strands_movebase/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(noise_approximate_voxel_grid src/noise_approximate_voxel_grid.cpp in
 ## Declare a cpp executable
 add_executable(subsample_cloud src/subsample_cloud.cpp)
 add_executable(remove_edges_cloud src/remove_edges_cloud.cpp)
+add_executable(remove_edges_laser src/remove_edges_laser.cpp)
 add_executable(mirror_floor_points src/mirror_floor_points.cpp)
 
 ## Add cmake target dependencies of the executable/library
@@ -93,6 +94,10 @@ target_link_libraries(subsample_cloud
 
 target_link_libraries(remove_edges_cloud
   ${catkin_LIBRARIES} ${PCL_LIBRARIES}
+)
+
+target_link_libraries(remove_edges_laser
+  ${catkin_LIBRARIES}
 )
 
 target_link_libraries(mirror_floor_points

--- a/strands_movebase/launch/movebase.launch
+++ b/strands_movebase/launch/movebase.launch
@@ -24,6 +24,7 @@
     <arg name="with_site_movebase_params" default="false"/>
     <arg name="site_movebase_params" default=""/>
 
+    <arg name="laser_angle_cutoff" default="10"/>
     <arg name="subsample_resolution" default="0.05"/>
     <arg name="subsample_min_points" default="5"/>
     <arg name="subsample_skip_points" default="20"/>
@@ -75,7 +76,7 @@
         <rosparam file="$(find strands_movebase)/strands_movebase_params/dwa_planner_ros.yaml" command="load"/>
         <param name="local_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
         <param name="global_costmap/obstacle_layer/point_cloud_sensor/min_obstacle_height" value="$(arg z_obstacle_threshold)"/>
-        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_xtion)">laser point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
+        <rosparam param="local_costmap/obstacle_layer/observation_sources" if="$(arg with_head_xtion)">laser_obstacle laser_clearing point_cloud_sensor clear_sensor cliff_sensor head_cloud_sensor head_clear_sensor</rosparam>
         <param name="local_costmap/obstacle_layer/publish_voxel_map" value="true"/>
         <param name="local_costmap/obstacle_layer/z_voxels" value="9" if="$(arg with_head_xtion)"/>
         <param name="local_costmap/obstacle_layer/unknown_threshold" value="9" if="$(arg with_head_xtion)"/>
@@ -91,6 +92,7 @@
 
         <arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
         <arg name="with_head_xtion" value="$(arg with_head_xtion)"/>
+        <arg name="laser_angle_cutoff" value="$(arg laser_angle_cutoff)"/>
         <arg name="resolution" value="$(arg subsample_resolution)"/>
         <arg name="min_points" value="$(arg subsample_min_points)"/>
         <arg name="skip_points" value="$(arg subsample_skip_points)"/>

--- a/strands_movebase/launch/movebase.launch
+++ b/strands_movebase/launch/movebase.launch
@@ -24,7 +24,7 @@
     <arg name="with_site_movebase_params" default="false"/>
     <arg name="site_movebase_params" default=""/>
 
-    <arg name="laser_angle_cutoff" default="10"/>
+    <arg name="laser_angle_cutoff" default="10.0"/>
     <arg name="subsample_resolution" default="0.05"/>
     <arg name="subsample_min_points" default="5"/>
     <arg name="subsample_skip_points" default="20"/>

--- a/strands_movebase/launch/obstacles.launch
+++ b/strands_movebase/launch/obstacles.launch
@@ -8,7 +8,7 @@
 
     <arg name="with_head_xtion" default="false"/>
 
-    <arg name="laser_angle_cutoff" default="10"/>
+    <arg name="laser_angle_cutoff" default="10.0"/>
     <arg name="resolution" default="0.05"/>
     <arg name="min_points" default="5"/>
     <arg name="skip_points" default="20"/>

--- a/strands_movebase/launch/obstacles.launch
+++ b/strands_movebase/launch/obstacles.launch
@@ -8,6 +8,7 @@
 
     <arg name="with_head_xtion" default="false"/>
 
+    <arg name="laser_angle_cutoff" default="10"/>
     <arg name="resolution" default="0.05"/>
     <arg name="min_points" default="5"/>
     <arg name="skip_points" default="20"/>
@@ -47,6 +48,13 @@
         <param name="output" value="/move_base/head_points_obstacle"/>
         <param name="cutoff" value="50.0"/>
         <param name="cutoff_z" value="0.3"/>
+    </node>
+
+    <!-- This node removes the desired cutoff pixels from the cloud edges -->
+    <node pkg="strands_movebase" type="remove_edges_laser" name="remove_edges_laser" output="screen">
+        <param name="input" value="/scan"/>
+        <param name="output" value="/move_base/scan_obstacle"/>
+        <param name="cutoff_angle" value="$(arg laser_angle_cutoff)"/>
     </node>
 
     <!-- This node enables us to visualize the 3d occupancy of the costmap -->

--- a/strands_movebase/src/remove_edges_laser.cpp
+++ b/strands_movebase/src/remove_edges_laser.cpp
@@ -1,14 +1,14 @@
 #include <ros/ros.h>
 #include <sensor_msgs/LaserScan.h>
 
-ros::Publisher pub; // publishes pointcloud with removed edges
+ros::Publisher pub; // publishes laser scan with removed edges
 float cutoff_angle; // how many angle to cut off in the laser
 
 void callback(const sensor_msgs::LaserScan::ConstPtr& msg)
 {
-    float angle_min = msg->angle_min + cutoff_angle;
-    float angle_max = msg->angle_max - cutoff_angle;
     int n_points = int(cutoff_angle / msg->angle_increment);
+    float angle_min = msg->angle_min + float(n_points)*msg->angle_increment;
+    float angle_max = msg->angle_max - float(n_points)*msg->angle_increment;
     int n_last = msg->ranges.size() - n_points;
     
     sensor_msgs::LaserScan msg_out;
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
 	ros::NodeHandle n;
 
     ros::NodeHandle pn("~");
-    // topic of input cloud
+    // topic of input laser scan
     if (!pn.hasParam("input")) {
         ROS_ERROR("Could not find parameter input.");
         return -1;
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
     std::string input;
     pn.getParam("input", input);
     
-    // topic of output cloud
+    // topic of output laser scan
     if (!pn.hasParam("output")) {
         ROS_ERROR("Could not find parameter output.");
         return -1;
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     std::string output;
     pn.getParam("output", output);
 
-    // how many pixels to cut off in the depth image
+    // how wide angle to cut off at the edges
 	if (!pn.hasParam("cutoff_angle")) {
         ROS_ERROR("Could not find parameter cutoff_angle.");
         return -1;

--- a/strands_movebase/src/remove_edges_laser.cpp
+++ b/strands_movebase/src/remove_edges_laser.cpp
@@ -22,14 +22,14 @@ void callback(const sensor_msgs::LaserScan::ConstPtr& msg)
     msg_out.scan_time = msg->scan_time;
     msg_out.range_min = msg->range_min;
     msg_out.range_max = msg->range_max;
-	msg_out.header = msg->header;
-	pub.publish(msg_out);
+    msg_out.header = msg->header;
+    pub.publish(msg_out);
 }
 
 int main(int argc, char** argv)
 {
     ros::init(argc, argv, "remove_edges_laser");
-	ros::NodeHandle n;
+    ros::NodeHandle n;
 
     ros::NodeHandle pn("~");
     // topic of input laser scan
@@ -57,10 +57,10 @@ int main(int argc, char** argv)
     pn.getParam("cutoff_angle", temp);
     cutoff_angle = M_PI/180.0*temp;
     
-	ros::Subscriber sub = n.subscribe(input, 1, callback);
+    ros::Subscriber sub = n.subscribe(input, 1, callback);
     pub = n.advertise<sensor_msgs::LaserScan>(output, 1);
     
     ros::spin();
 	
-	return 0;
+    return 0;
 }

--- a/strands_movebase/src/remove_edges_laser.cpp
+++ b/strands_movebase/src/remove_edges_laser.cpp
@@ -1,0 +1,51 @@
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+
+ros::Publisher pub; // publishes pointcloud with removed edges
+double cutoff_angle; // how many angle to cut off in the laser
+
+void callback(const sensor_msgs::LaserScan::ConstPtr& msg)
+{
+    sensor_msgs::LaserScan msg_out = *msg;
+    msg_out.angle_min = msg->angle_min + cutoff_angle;
+    msg_out.angle_max = msg->angle_max - cutoff_angle;
+	msg_out.header = msg->header;
+	pub.publish(msg_out);
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "remove_edges_laser");
+	ros::NodeHandle n;
+
+    ros::NodeHandle pn("~");
+    // topic of input cloud
+    if (!pn.hasParam("input")) {
+        ROS_ERROR("Could not find parameter input.");
+        return -1;
+    }
+    std::string input;
+    pn.getParam("input", input);
+    
+    // topic of output cloud
+    if (!pn.hasParam("output")) {
+        ROS_ERROR("Could not find parameter output.");
+        return -1;
+    }
+    std::string output;
+    pn.getParam("output", output);
+
+    // how many pixels to cut off in the depth image
+	if (!pn.hasParam("cutoff_angle")) {
+        ROS_ERROR("Could not find parameter cutoff_angle.");
+        return -1;
+    }
+    pn.getParam("cutoff_angle", cutoff_angle);
+    
+	ros::Subscriber sub = n.subscribe(input, 1, callback);
+    pub = n.advertise<sensor_msgs::LaserScan>(output, 1);
+    
+    ros::spin();
+	
+	return 0;
+}

--- a/strands_movebase/strands_movebase_params/costmap_common_params.yaml
+++ b/strands_movebase/strands_movebase_params/costmap_common_params.yaml
@@ -37,9 +37,11 @@ obstacle_layer:
   unknown_threshold: 6
   mark_threshold: 0
 
-  observation_sources: laser point_cloud_sensor clear_sensor cliff_sensor
+  observation_sources: laser_obstacle laser_clearing point_cloud_sensor clear_sensor cliff_sensor
 
-  laser: {sensor_frame: base_laser_link, data_type: LaserScan, topic: scan, marking: true, clearing: true}
+  laser_obstacle: {sensor_frame: base_laser_link, data_type: LaserScan, topic: /move_base/scan_obstacle, marking: true, clearing: false}
+
+  laser_clearing: {sensor_frame: base_laser_link, data_type: LaserScan, topic: scan, marking: false, clearing: true}
 
   point_cloud_sensor: {topic: /move_base/points_obstacle, data_type: PointCloud2, marking: true, clearing: false, min_obstacle_height: 0.1, max_obstacle_height: 0.9, observation_persistence: 0.0, obstacle_range: 2.0}
 


### PR DESCRIPTION
This pull request adds a new node, `remove_edges_laser` that removes a small angle at the beginning and end of the laser scan. This new scan is then used to add obstacles in the costmap while the old, full, scan is used for clearing them. This should solve https://github.com/strands-project/strands_movebase/issues/25 .

Since I am unable to try this out on Rosie atm (going on 48 hours now=P) and we are performing a marathon, I would encourage those that think that this affects the performance of their robot's navigation to try it before we merge. @BFALacerda @lucasb-eyer 
