### PR TITLE
[calibrate_chest] Add action server with check for correct angle

### DIFF
--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -4,7 +4,7 @@ project(calibrate_chest)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs mongodb_store actionlib_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs mongodb_store actionlib actionlib_msgs)
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS thread)
@@ -38,15 +38,16 @@ add_definitions(${PCL_DEFINITIONS})
 #   Service2.srv
 # )
 
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   sensor_msgs#   std_msgs
-# )
-
 add_action_files(
   DIRECTORY action
   FILES CalibrateCamera.action
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  actionlib_msgs
 )
 
 ###################################

--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -4,7 +4,7 @@ project(calibrate_chest)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs mongodb_store)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs mongodb_store actionlib_msgs)
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS thread)
@@ -44,6 +44,11 @@ add_definitions(${PCL_DEFINITIONS})
 #   sensor_msgs#   std_msgs
 # )
 
+add_action_files(
+  DIRECTORY action
+  FILES CalibrateCamera.action
+)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -57,7 +62,7 @@ catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES calibrate_chest
 #  CATKIN_DEPENDS roscpp sensor_msgs std_msgs
-#  DEPENDS system_lib
+  DEPENDS actionlib_msgs
 )
 
 ###########
@@ -79,10 +84,12 @@ include_directories(
 ## Declare a cpp executable
 add_executable(calibrate_chest src/calibrate_chest.cpp)
 add_executable(chest_calibration_publisher src/chest_calibration_publisher.cpp)
+add_executable(calibration_server src/calibration_server.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 add_dependencies(calibrate_chest mongodb_store_generate_messages_cpp)
+add_dependencies(calibration_server mongodb_store_generate_messages_cpp calibrate_chest_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(calibrate_chest
@@ -90,6 +97,10 @@ target_link_libraries(calibrate_chest
 )
 
 target_link_libraries(chest_calibration_publisher
+  ${catkin_LIBRARIES} ${PCL_LIBRARIES}
+)
+
+target_link_libraries(calibration_server
   ${catkin_LIBRARIES} ${PCL_LIBRARIES}
 )
 

--- a/calibrate_chest/action/CalibrateCamera.action
+++ b/calibrate_chest/action/CalibrateCamera.action
@@ -1,0 +1,11 @@
+#goal definition
+string command
+---
+#result definition
+string status
+float32 angle
+float32 height
+---
+#feedback definition
+string status
+float32 progress

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -44,6 +44,7 @@
   <build_depend>pcl_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>actionlib_msgs</build_depend>
+  <build_depend>actionlib</build_depend>
   
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
@@ -52,6 +53,7 @@
   <run_depend>pcl_ros</run_depend>
   <run_depend>libpcl-all</run_depend>
   <run_depend>actionlib_msgs</run_depend>
+  <run_depend>actionlib</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/calibrate_chest/package.xml
+++ b/calibrate_chest/package.xml
@@ -43,6 +43,7 @@
   <build_depend>mongodb_store</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
   
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
@@ -50,6 +51,7 @@
   <run_depend>mongodb_store</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>libpcl-all</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/calibrate_chest/src/calibration_server.cpp
+++ b/calibrate_chest/src/calibration_server.cpp
@@ -247,7 +247,7 @@ public:
     void execute_cb(const calibrate_chest::CalibrateCameraGoalConstPtr& goal)
     {
         if (goal->command == "calibrate") {
-            sensor_msgs::PointCloud2::ConstPtr msg = ros::topic::waitForMessage<sensor_msgs::PointCloud2>(camera_topic, n);
+            sensor_msgs::PointCloud2::ConstPtr msg = ros::topic::waitForMessage<sensor_msgs::PointCloud2>(camera_topic, n, ros::Duration(5));
             if (msg) {
                 msg_callback(msg);
             }

--- a/calibrate_chest/src/calibration_server.cpp
+++ b/calibrate_chest/src/calibration_server.cpp
@@ -8,9 +8,10 @@
 #include "mongodb_store/SetParam.h"
 
 #include <actionlib/server/simple_action_server.h>
-#include <calibrate_chest/CalibrateCamera.h>
+#include <calibrate_chest/CalibrateCameraAction.h>
 
 class CalibrateCameraServer {
+private:
 
     bool do_calibrate; // register and unregister instead
     ros::NodeHandle n;
@@ -22,9 +23,11 @@ class CalibrateCameraServer {
     calibrate_chest::CalibrateCameraFeedback feedback;
     calibrate_chest::CalibrateCameraResult result;
 
+public:
+
     CalibrateCameraServer(const std::string& name, const std::string& camera_name) :
         do_calibrate(false),
-        server(nh, name, boost::bind(&CalibrateCameraServer::execute_cb, this, _1), false),
+        server(n, name, boost::bind(&CalibrateCameraServer::execute_cb, this, _1), false),
         action_name(name),
         client(n.serviceClient<mongodb_store::SetParam>("/config_manager/set_param")),
         camera_topic(camera_name + "/depth/points")
@@ -32,6 +35,8 @@ class CalibrateCameraServer {
         sub = n.subscribe(camera_topic, 1, &CalibrateCameraServer::msg_callback, this);
         server.start();
     }
+
+private:
 
     bool is_inlier(const Eigen::Vector3f& point, const Eigen::Vector4f plane, double threshold) const
     {
@@ -127,6 +132,8 @@ class CalibrateCameraServer {
         result.status = "Successfully computed and saved calibration.";
         server.setSucceeded(result);
     }
+
+public:
 
     void msg_callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
     {

--- a/calibrate_chest/src/calibration_server.cpp
+++ b/calibrate_chest/src/calibration_server.cpp
@@ -162,14 +162,15 @@ private:
             joint_state.velocity[0] = 0;
             joint_state.velocity[1] = 0;
             pub.publish(joint_state);
-            rate.sleep();
-            ++counter;
 
             feedback.progress = float(counter+1)/5.0f;
             server.publishFeedback(feedback);
+
+            rate.sleep();
+            ++counter;
         }
 
-        ROS_INFO("Stopping to publish chest transform after 10 seconds, quitting...");
+        ROS_INFO("Stopping to publish chest transform after 5 seconds, quitting...");
 
         result.status = "Published calibration.";
         result.angle = 180.0f/M_PI*angle;
@@ -230,7 +231,7 @@ public:
                 best_inliers = inliers;
             }
 
-            if (i % 10 == 0) {
+            if (i % 10 == 0 || i == max - 1) {
                 feedback.progress = float(i+1)/float(max);
                 server.publishFeedback(feedback);
             }

--- a/calibrate_chest/src/calibration_server.cpp
+++ b/calibrate_chest/src/calibration_server.cpp
@@ -1,0 +1,208 @@
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <boost/thread/thread.hpp>
+#include "mongodb_store/SetParam.h"
+
+#include <actionlib/server/simple_action_server.h>
+#include <calibrate_chest/CalibrateCamera.h>
+
+class CalibrateCameraServer {
+
+    bool do_calibrate; // register and unregister instead
+    ros::NodeHandle n;
+    actionlib::SimpleActionServer<calibrate_chest::CalibrateCameraAction> server;
+    std::string action_name;
+    ros::ServiceClient client;
+    ros::Subscriber sub;
+    std::string camera_topic;
+    calibrate_chest::CalibrateCameraFeedback feedback;
+    calibrate_chest::CalibrateCameraResult result;
+
+    CalibrateCameraServer(const std::string& name, const std::string& camera_name) :
+        do_calibrate(false),
+        server(nh, name, boost::bind(&CalibrateCameraServer::execute_cb, this, _1), false),
+        action_name(name),
+        client(n.serviceClient<mongodb_store::SetParam>("/config_manager/set_param")),
+        camera_topic(camera_name + "/depth/points")
+    {
+        sub = n.subscribe(camera_topic, 1, &CalibrateCameraServer::msg_callback, this);
+        server.start();
+    }
+
+    bool is_inlier(const Eigen::Vector3f& point, const Eigen::Vector4f plane, double threshold) const
+    {
+        return fabs(point.dot(plane.segment<3>(0)) + plane(3)) < threshold;
+    }
+
+    void plot_best_plane(const pcl::PointCloud<pcl::PointXYZ>& points, const Eigen::Vector4f plane, double threshold) const
+    {
+        pcl::PointCloud<pcl::PointXYZ>::Ptr inlier_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+        pcl::PointCloud<pcl::PointXYZ>::Ptr outlier_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+        
+        for (int i = 0; i < points.size(); ++i) {
+            if (is_inlier(points[i].getVector3fMap(), plane, threshold)) {
+                inlier_cloud->push_back(points[i]);
+            }
+            else {
+                outlier_cloud->push_back(points[i]);
+            }
+        }
+        
+        pcl::visualization::PCLVisualizer viewer("3D Viewer");
+        viewer.setBackgroundColor(0, 0, 0);
+        viewer.addCoordinateSystem(1.0);
+        viewer.initCameraParameters();
+        
+        pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> inlier_color_handler(inlier_cloud, 255, 0, 0);
+        viewer.addPointCloud(inlier_cloud, inlier_color_handler, "inliers");
+        
+        pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> outlier_color_handler(outlier_cloud, 0, 0, 255);
+        viewer.addPointCloud(outlier_cloud, outlier_color_handler, "outliers");
+        
+        while (!viewer.wasStopped())
+        {
+            viewer.spinOnce(100);
+            boost::this_thread::sleep(boost::posix_time::microseconds(100000));
+        }
+        
+    }
+
+    void compute_plane(Eigen::Vector4f& plane, const pcl::PointCloud<pcl::PointXYZ>& points, int* inds) const
+    {
+        Eigen::Vector3f first = points[inds[1]].getVector3fMap() - points[inds[0]].getVector3fMap();
+        Eigen::Vector3f second = points[inds[2]].getVector3fMap() - points[inds[0]].getVector3fMap();
+        Eigen::Vector3f normal = first.cross(second);
+        normal.normalize();
+        plane.segment<3>(0) = normal;
+        plane(3) = -normal.dot(points[inds[0]].getVector3fMap());
+    }
+
+    void extract_height_and_angle(const Eigen::Vector4f& plane)
+    {
+        feedback.status = "Checking and saving calibration...";
+        server.publishFeedback(feedback);
+
+        ROS_INFO("Ground plane: %f, %f, %f, %f", plane(0), plane(1), plane(2), plane(3));
+        double dist = fabs(plane(3)/plane(2)); // distance along z axis
+        double height = fabs(plane(3)/plane.segment<3>(0).squaredNorm()); // height
+        ROS_INFO("Distance to plane along camera axis: %f", dist);
+        ROS_INFO("Height above ground: %f", height);
+        double angle = asin(height/dist);
+        double angle_deg = 180.0f*angle/M_PI;
+        ROS_INFO("Angle radians: %f", angle);
+        ROS_INFO("Angle degrees: %f", angle_deg);
+
+        result.angle = angle_deg;
+        result.height = height;
+
+        if (fabs(45.0f - angle_deg) > 3.0f) {
+            result.status = "Angle not close enough to 45 degrees.";
+            server.setAborted(result);
+            return;
+        }
+        
+        mongodb_store::SetParam srv;
+        char buffer[250];
+        
+        // store height above ground in datacentre
+        ros::param::set("/chest_xtion_height", height);
+        sprintf(buffer, "{\"path\":\"/chest_xtion_height\",\"value\":%f}", height);
+        srv.request.param = buffer;
+        if (!client.call(srv)) {
+            ROS_ERROR("Failed to call set height, is config manager running?");
+        }
+        
+        // store angle between camera and horizontal plane
+        ros::param::set("/chest_xtion_angle", angle);
+        sprintf(buffer, "{\"path\":\"/chest_xtion_angle\",\"value\":%f}", angle);
+        srv.request.param = buffer;
+        if (!client.call(srv)) {
+            ROS_ERROR("Failed to call set angle, is config manager running?");
+        }
+
+        result.status = "Successfully computed and saved calibration.";
+        server.setSucceeded(result);
+    }
+
+    void msg_callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
+    {
+        if (!do_calibrate) {
+            return;
+        }
+        do_calibrate = false;
+
+        feedback.status = "Calibrating...";
+        feedback.progress = 0.0f;
+        server.publishFeedback(feedback);
+
+        ROS_INFO("Got a pointcloud, calibrating...");
+        pcl::PointCloud<pcl::PointXYZ> cloud;
+        pcl::fromROSMsg(*msg, cloud);
+        
+        int nbr = cloud.size();
+        
+        int max = 1000; // ransac iterations
+        double threshold = 0.02; // threshold for plane inliers
+        
+        Eigen::Vector4f best_plane; // best plane parameters found
+        int best_inliers = -1; // best number of inliers
+        
+        int inds[3];
+        
+        Eigen::Vector4f plane;
+        int inliers;
+        for (int i = 0; i < max; ++i) {
+            
+            for (int j = 0; j < 3; ++j) {
+                inds[j] = rand() % nbr; // get a random point
+            }
+            
+            // check that the points aren't the same
+            if (inds[0] == inds[1] || inds[0] == inds[2] || inds[1] == inds[2]) {
+                continue;
+            }
+            
+            compute_plane(plane, cloud, inds);
+            inliers = 0;
+            for (int j = 0; j < nbr; j += 30) { // count number of inliers
+                if (is_inlier(cloud[j].getVector3fMap(), plane, threshold)) {
+                    ++inliers;
+                }
+            }
+            
+            if (inliers > best_inliers) {
+                best_plane = plane;
+                best_inliers = inliers;
+                feedback.progress = float(i+1)/float(max);
+                server.publishFeedback(feedback);
+            }
+        }
+        
+        extract_height_and_angle(best_plane); // find parameters and feed them to datacentre
+        //plot_best_plane(cloud, best_plane, threshold); // visually evaluate plane fit
+    }
+
+    void execute_cb(const calibrate_chest::CalibrateCameraGoalConstPtr& goal)
+    {
+        if (goal->command == "calibrate") {
+            do_calibrate = true;
+        }
+        else {
+            result.status = "Enter command \"calibrate\" or \"publish\".";
+            server.setAborted(result);
+        }
+    }
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "calibrate_chest");
+    CalibrateCameraServer calibrate(ros::this_node::getName(), "chest_xtion");
+    ros::spin();
+	
+	return 0;
+}


### PR DESCRIPTION
This adds a new action server node with action server named `calibrate_chest` that
- Computes the transformation if you send command `calibrate`
- Publishes the transformation if you send command `publish`

It also has instructions if you send the wrong command and checks that the angle is close enough to the desired 46 degrees. If it is too far away, it does not send the calibration and returns a warning.

Test with `rosrun actionlib axclient.py /calibrate_chest` and enter the commands above.
