### PR TITLE
[movebase_state_service] Service that returns current costmaps with plans overlaid

### DIFF
--- a/movebase_state_service/CMakeLists.txt
+++ b/movebase_state_service/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
                     roscpp
                     sensor_msgs
                     std_msgs
-                    pcl_ros
                     tf
                     costmap_2d
                     navfn
@@ -92,3 +91,9 @@ target_link_libraries(movebase_state_service
   ${catkin_LIBRARIES} ${OpenCV_LIBS}
 )
 
+## Mark executables and/or libraries for installation
+install(TARGETS movebase_state_service
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/movebase_state_service/CMakeLists.txt
+++ b/movebase_state_service/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(movebase_state_service)
+
+add_definitions(-std=c++0x)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+                    roscpp
+                    sensor_msgs
+                    std_msgs
+                    pcl_ros
+                    tf
+                    costmap_2d
+                    navfn
+                    nav_core
+                    cv_bridge
+                    nav_msgs
+                    geometry_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+find_package(OpenCV REQUIRED)
+
+## Generate messages in the 'msg' folder
+#~ add_message_files(
+  #~ DEPENDENCIES actionlib_msgs std_msgs
+#~ )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+add_service_files(
+  FILES
+  MovebaseStateService.srv
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+    DEPENDENCIES
+    std_msgs  # Or other packages containing msgs
+    sensor_msgs
+#    actionlib_msgs
+)
+
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES dynamic_layer overwrite_layer smart_obstacle_layer unleash_static_planner static_planner 
+#  CATKIN_DEPENDS costmap_2d dynamic_reconfigure roscpp nav_core actionlib_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  #include
+)
+
+## Declare a cpp library
+#add_library(noise_voxel_grid src/noise_voxel_grid.cpp)
+#add_library(noise_approximate_voxel_grid src/noise_approximate_voxel_grid.cpp)
+
+## Declare a cpp executable
+add_executable(movebase_state_service src/movebase_state_service.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+#add_dependencies(scitos_2d_navigation_node scitos_2d_navigation_generate_messages_cpp)
+add_dependencies(movebase_state_service movebase_state_service_generate_messages_cpp)
+target_link_libraries(movebase_state_service
+  ${catkin_LIBRARIES} ${OpenCV_LIBS}
+)
+

--- a/movebase_state_service/package.xml
+++ b/movebase_state_service/package.xml
@@ -3,11 +3,8 @@
   <name>movebase_state_service</name>
   <version>0.0.2</version>
   <description>
-    This package contains components for using the ROS move base together
-    with the Scitos G5 robot. There is options for running obstacle avoidance
-    both with only laser and with an additional depth-sensing camera
-    mounted in front. The additional nodes in the package are for processing
-    the incoming clouds from the camera for obstacle avoidance.
+    This service returns the local and global costmaps as image with the global and local plans overlaid.
+    It also returns the last image from the camera.
   </description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/movebase_state_service/package.xml
+++ b/movebase_state_service/package.xml
@@ -33,7 +33,6 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>costmap_2d</build_depend>
   <build_depend>nav_core</build_depend>
@@ -45,7 +44,6 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>pcl_ros</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>costmap_2d</run_depend>
   <run_depend>cv_bridge</run_depend>

--- a/movebase_state_service/package.xml
+++ b/movebase_state_service/package.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package>
+  <name>movebase_state_service</name>
+  <version>0.0.2</version>
+  <description>
+    This package contains components for using the ROS move base together
+    with the Scitos G5 robot. There is options for running obstacle avoidance
+    both with only laser and with an additional depth-sensing camera
+    mounted in front. The additional nodes in the package are for processing
+    the incoming clouds from the camera for obstacle avoidance.
+  </description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <maintainer email="nilsbore@gmail.com">nbore</maintainer>
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <url type="website">http://github.com/strands-project/scitos_2d_navigation</url>
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <author email="nilsbore@gmail.com">Nils Bore</author>
+  <author email="b.lacerda@cs.bham.ac.uk">Bruno Lacerda</author>
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>pcl_ros</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>costmap_2d</build_depend>
+  <build_depend>nav_core</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <run_depend>nav_core</run_depend>
+  <run_depend>message_runtime</run_depend> <!-- try -->
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>pcl_ros</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>costmap_2d</run_depend>
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>nav_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <!-- The export tag contains other, unspecified, tags -->
+  <!-- <export> -->
+
+  <!-- </export> -->
+</package>
+

--- a/movebase_state_service/src/movebase_state_service.cpp
+++ b/movebase_state_service/src/movebase_state_service.cpp
@@ -1,0 +1,262 @@
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+#include <costmap_2d/costmap_2d_ros.h>
+#include <navfn/navfn_ros.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Pose.h>
+#include <nav_msgs/Path.h>
+#include <string>
+#include "movebase_state_service/MovebaseStateService.h"
+
+class state_service {
+
+public:
+
+    ros::NodeHandle n;
+    ros::ServiceServer service;
+
+    //sensor_msgs::Image::ConstPtr last_img;
+    //nav_msgs::OccupancyGrid::ConstPtr global_last_map;
+    //nav_msgs::OccupancyGrid::ConstPtr local_last_map;
+    geometry_msgs::PoseStampedConstPtr last_goal;
+    geometry_msgs::PoseConstPtr last_pose;
+    nav_msgs::Path::ConstPtr global_last_path;
+    nav_msgs::Path::ConstPtr local_last_path;
+    std::string snapshot_folder;
+    int counter;
+
+    ros::Subscriber goal_sub;
+    ros::Subscriber pose_sub;
+    ros::Subscriber global_path_sub;
+    ros::Subscriber local_path_sub;
+
+    std::string image_input;
+    std::string global_costmap_input;
+    std::string local_costmap_input;
+    std::string goal_input;
+    std::string pose_input;
+    std::string global_path_input;
+    std::string local_path_input;
+
+    state_service()
+    {
+        // Initialize node parameters from launch file or command line.
+        // Use a private node handle so that multiple instances of the node can be run simultaneously
+        // while using different parameters.
+        ros::NodeHandle pn("~");
+        pn.param<std::string>("image_input", image_input, std::string("/head_xtion/rgb/image_color"));
+        pn.param<std::string>("global_costmap_input", global_costmap_input, std::string("/move_base/global_costmap/costmap"));
+        pn.param<std::string>("local_costmap_input", local_costmap_input, std::string("/move_base/local_costmap/costmap"));
+        pn.param<std::string>("snapshot_folder", snapshot_folder, std::string(getenv("HOME")) + std::string("/.ros/state_snapshot_service"));
+        pn.param<std::string>("goal_input", goal_input, std::string("/move_base/current_goal"));
+        pn.param<std::string>("pose_input", pose_input, std::string("/robot_pose"));
+        pn.param<std::string>("global_path_input", global_path_input, std::string("/move_base/NavfnROS/plan"));
+        pn.param<std::string>("local_path_input", local_path_input, std::string("TrajectoryPlannerROS/local_plan"));
+
+        //ros::Subscriber image_sub = n.subscribe(image_input, 1, image_callback);
+        //ros::Subscriber global_costmap_sub = n.subscribe(global_costmap_input, 1, global_costmap_callback);
+        //ros::Subscriber local_costmap_sub = n.subscribe(local_costmap_input, 1, local_costmap_callback);
+        goal_sub = n.subscribe(goal_input, 1, &state_service::goal_callback, this);
+        pose_sub = n.subscribe(pose_input, 1, &state_service::pose_callback, this);
+        global_path_sub = n.subscribe(global_path_input, 1, &state_service::global_path_callback, this);
+        local_path_sub = n.subscribe(local_path_input, 1, &state_service::local_path_callback, this);
+        counter = 0;
+
+        service = n.advertiseService("save_state_service", &state_service::service_callback, this);
+    }
+
+    /*void image_callback(const sensor_msgs::Image::ConstPtr& image_msg)
+    {
+        last_img = image_msg;
+    }
+
+    void global_costmap_callback(const nav_msgs::OccupancyGrid::ConstPtr& map_msg)
+    {
+        global_last_map = map_msg;
+    }
+
+    void local_costmap_callback(const nav_msgs::OccupancyGrid::ConstPtr& map_msg)
+    {
+        local_last_map = map_msg;
+    }*/
+
+    void goal_callback(const geometry_msgs::PoseStampedConstPtr& goal_msg)
+    {
+        last_goal = goal_msg;
+    }
+
+    void pose_callback(const geometry_msgs::PoseConstPtr& pose_msg)
+    {
+        last_pose = pose_msg;
+    }
+
+    void global_path_callback(const nav_msgs::Path::ConstPtr& path_msg)
+    {
+        global_last_path = path_msg;
+    }
+
+    void local_path_callback(const nav_msgs::Path::ConstPtr& path_msg)
+    {
+        local_last_path = path_msg;
+    }
+
+    void color_around_point(cv::Mat& map, int x, int y, int c)
+    {
+        for (int i = x - 2; i < x + 3; ++i) {
+            for (int j = y - 2; j < y + 3; ++j) {
+                // add out-of-bounds check
+                if (i < 0 || i >= map.cols || j < 0 || j >= map.rows) {
+                    continue;
+                }
+                map.at<cv::Vec3b>(j, i)[0] = 0;
+                map.at<cv::Vec3b>(j, i)[1] = 0;
+                map.at<cv::Vec3b>(j, i)[2] = 0;
+                map.at<cv::Vec3b>(j, i)[c] = 255;
+            }
+        }
+
+    }
+
+    void save_map(sensor_msgs::Image& image_msg, const std::string& map_file, const std::string& rgb_map_file,
+                  nav_msgs::OccupancyGrid::ConstPtr& last_map, nav_msgs::Path::ConstPtr& last_path, bool save_to_disk)
+    {
+        // save map
+        double map_height = last_map->info.height;
+        double map_width = last_map->info.width;
+        double map_origin_x = last_map->info.origin.position.x;
+        double map_origin_y = last_map->info.origin.position.y;
+        double map_res = last_map->info.resolution;
+        //mod_num = (int)(map_res/0.05 + 0.5); // solve generically! (0.05 = master_map.resolution...)
+        ROS_INFO_STREAM("Map width x height: " << map_width << " x " << map_height);
+        // just copy dynamicMap for tableMap and dynMap
+        costmap_2d::Costmap2D map(map_width, map_height, map_res, map_origin_x, map_origin_y);
+
+        cv::Mat image = cv::Mat::zeros(map_height, map_width, CV_8UC3);
+
+        // incoming dynamic map to Costmap2D
+        for(int i = 0; i < map_width; i++) {
+            for(int j = 0; j < map_height; j++) {
+                map.setCost(i, j, last_map->data[map.getIndex(i, j)]);
+                image.at<cv::Vec3b>(j, i)[0] = last_map->data[map.getIndex(i, j)];
+                image.at<cv::Vec3b>(j, i)[1] = last_map->data[map.getIndex(i, j)];
+                image.at<cv::Vec3b>(j, i)[2] = last_map->data[map.getIndex(i, j)];
+            }
+        }
+
+        double x, y;
+        int map_x, map_y;
+
+        if (last_path) {
+            for (size_t i = 0; i < last_path->poses.size(); ++i) {
+                x = last_path->poses[i].pose.position.x;
+                y = last_path->poses[i].pose.position.y;
+                map.worldToMapEnforceBounds(x, y, map_x, map_y);
+                color_around_point(image, map_x, map_y, 1);
+            }
+        }
+
+        if (last_goal) {
+            x = last_goal->pose.position.x;
+            y = last_goal->pose.position.y;
+            map.worldToMapEnforceBounds(x, y, map_x, map_y);
+            color_around_point(image, map_x, map_y, 2);
+        }
+
+        if (last_pose) {
+            x = last_pose->position.x;
+            y = last_pose->position.y;
+            map.worldToMapEnforceBounds(x, y, map_x, map_y);
+            color_around_point(image, map_x, map_y, 0);
+        }
+
+        if (save_to_disk) {
+            map.saveMap(map_file);
+            // use lossless png compression
+            std::vector<int> compression;
+            compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+            compression.push_back(0); // no compression
+            cv::imwrite(rgb_map_file, image, compression);
+        }
+
+        std_msgs::Header header;
+        header.seq = counter;
+        header.stamp = ros::Time::now();
+        header.frame_id = "/map";
+
+        cv_bridge::CvImage global_costmap_tmp = cv_bridge::CvImage(header, "8UC3", image);
+        global_costmap_tmp.toImageMsg(image_msg);
+    }
+
+    bool service_callback(movebase_state_service::MovebaseStateService::Request& req,
+                          movebase_state_service::MovebaseStateService::Response& res)
+    {
+        sensor_msgs::Image::ConstPtr last_img = ros::topic::waitForMessage<sensor_msgs::Image>(image_input, n, ros::Duration(5));
+        if (!last_img) {
+            return false;
+        }
+
+        if (req.save_to_disk) {
+            // save image
+            boost::shared_ptr<sensor_msgs::Image> rgb_tracked_object;
+            cv_bridge::CvImageConstPtr rgb_cv_img_boost_ptr;
+            try {
+                rgb_cv_img_boost_ptr = cv_bridge::toCvShare(*last_img, rgb_tracked_object);
+            }
+            catch (cv_bridge::Exception& e) {
+                ROS_ERROR("cv_bridge exception: %s", e.what());
+                return false;
+            }
+            // use lossless png compression
+            std::vector<int> compression;
+            compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+            compression.push_back(0); // no compression
+
+            //char buffer[250];
+            //sprintf(buffer, "%s/image%06d.png", snapshot_folder.c_str(), counter);
+            std::string image_file = snapshot_folder + "/image" + std::to_string(counter) + ".png";
+            cv::imwrite(image_file, rgb_cv_img_boost_ptr->image, compression);
+        }
+        res.camera_image = *last_img;
+
+        nav_msgs::OccupancyGrid::ConstPtr global_costmap_msg = ros::topic::waitForMessage<nav_msgs::OccupancyGrid>(global_costmap_input, n, ros::Duration(5));
+        if (!global_costmap_msg) {
+            return false;
+        }
+        std::string global_map_file = snapshot_folder + "/global_costmap" + std::to_string(counter) + ".pgm";
+        std::string global_rgb_map_file = snapshot_folder + "/global_costmap_path" + std::to_string(counter) + ".png";
+        //save_map(global_map_file, global_rgb_map_file, global_last_map, global_last_path);
+        save_map(res.global_costmap_image, global_map_file, global_rgb_map_file, global_costmap_msg, global_last_path, req.save_to_disk);
+
+        nav_msgs::OccupancyGrid::ConstPtr local_costmap_msg = ros::topic::waitForMessage<nav_msgs::OccupancyGrid>(local_costmap_input, n, ros::Duration(5));
+        if (!local_costmap_msg) {
+            return false;
+        }
+        std::string local_map_file = snapshot_folder + "/local_costmap" + std::to_string(counter) + ".pgm";
+        std::string local_rgb_map_file = snapshot_folder + "/local_costmap_path" + std::to_string(counter) + ".png";
+        //save_map(local_map_file, local_rgb_map_file, local_last_map, local_last_path);
+        save_map(res.local_costmap_image, local_map_file, local_rgb_map_file, local_costmap_msg, local_last_path, req.save_to_disk);
+
+        /*res.folder = snapshot_folder;
+        res.image_file = image_file;
+        res.global_costmap_file = global_rgb_map_file;
+        res.local_costmap_file = local_rgb_map_file;*/
+
+        ++counter;
+
+        return true;
+    }
+
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "movebase_state_service");
+
+    state_service();
+    
+    ros::spin();
+    
+    return 0;
+}

--- a/movebase_state_service/src/movebase_state_service.cpp
+++ b/movebase_state_service/src/movebase_state_service.cpp
@@ -2,6 +2,7 @@
 #include <sensor_msgs/Image.h>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui.hpp>
 #include <costmap_2d/costmap_2d_ros.h>
 #include <navfn/navfn_ros.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -149,7 +150,7 @@ public:
             map.saveMap(map_file);
             // use lossless png compression
             std::vector<int> compression;
-            compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+            compression.push_back(cv::IMWRITE_PNG_COMPRESSION);
             compression.push_back(0); // no compression
             cv::imwrite(rgb_map_file, image, compression);
         }
@@ -184,7 +185,7 @@ public:
             }
             // use lossless png compression
             std::vector<int> compression;
-            compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+            compression.push_back(cv::IMWRITE_PNG_COMPRESSION);
             compression.push_back(0); // no compression
 
             std::string image_file = snapshot_folder + "/image" + std::to_string(counter) + ".png";

--- a/movebase_state_service/src/movebase_state_service.cpp
+++ b/movebase_state_service/src/movebase_state_service.cpp
@@ -46,8 +46,8 @@ public:
         pn.param<std::string>("snapshot_folder", snapshot_folder, std::string(getenv("HOME")) + std::string("/.ros/movebase_state_service"));
         pn.param<std::string>("goal_input", goal_input, std::string("/move_base/current_goal"));
         pn.param<std::string>("pose_input", pose_input, std::string("/robot_pose"));
-        pn.param<std::string>("global_path_input", global_path_input, std::string("/move_base/NavfnROS/plan"));
-        pn.param<std::string>("local_path_input", local_path_input, std::string("TrajectoryPlannerROS/local_plan"));
+        pn.param<std::string>("global_path_input", global_path_input, std::string("/move_base/DWAPlannerROS/global_plan"));
+        pn.param<std::string>("local_path_input", local_path_input, std::string("/move_base/DWAPlannerROS/local_plan"));
 
         goal_sub = n.subscribe(goal_input, 1, &state_service::goal_callback, this);
         pose_sub = n.subscribe(pose_input, 1, &state_service::pose_callback, this);

--- a/movebase_state_service/src/movebase_state_service.cpp
+++ b/movebase_state_service/src/movebase_state_service.cpp
@@ -15,6 +15,7 @@ class state_service {
 public:
 
     ros::NodeHandle n;
+    //ros::NodeHandle pn; 
     ros::ServiceServer service;
 
     //sensor_msgs::Image::ConstPtr last_img;
@@ -40,7 +41,7 @@ public:
     std::string global_path_input;
     std::string local_path_input;
 
-    state_service()
+    state_service(const std::string& name) //: n(), pn("~")
     {
         // Initialize node parameters from launch file or command line.
         // Use a private node handle so that multiple instances of the node can be run simultaneously
@@ -64,7 +65,7 @@ public:
         local_path_sub = n.subscribe(local_path_input, 1, &state_service::local_path_callback, this);
         counter = 0;
 
-        service = n.advertiseService("save_state_service", &state_service::service_callback, this);
+        service = n.advertiseService(name, &state_service::service_callback, this);
     }
 
     /*void image_callback(const sensor_msgs::Image::ConstPtr& image_msg)
@@ -254,7 +255,7 @@ int main(int argc, char** argv)
 {
     ros::init(argc, argv, "movebase_state_service");
 
-    state_service();
+    state_service sc(ros::this_node::getName());
     
     ros::spin();
     

--- a/movebase_state_service/src/movebase_state_service.cpp
+++ b/movebase_state_service/src/movebase_state_service.cpp
@@ -49,7 +49,7 @@ public:
         pn.param<std::string>("image_input", image_input, std::string("/head_xtion/rgb/image_color"));
         pn.param<std::string>("global_costmap_input", global_costmap_input, std::string("/move_base/global_costmap/costmap"));
         pn.param<std::string>("local_costmap_input", local_costmap_input, std::string("/move_base/local_costmap/costmap"));
-        pn.param<std::string>("snapshot_folder", snapshot_folder, std::string(getenv("HOME")) + std::string("/.ros/state_snapshot_service"));
+        pn.param<std::string>("snapshot_folder", snapshot_folder, std::string(getenv("HOME")) + std::string("/.ros/movebase_state_service"));
         pn.param<std::string>("goal_input", goal_input, std::string("/move_base/current_goal"));
         pn.param<std::string>("pose_input", pose_input, std::string("/robot_pose"));
         pn.param<std::string>("global_path_input", global_path_input, std::string("/move_base/NavfnROS/plan"));

--- a/movebase_state_service/srv/MovebaseStateService.srv
+++ b/movebase_state_service/srv/MovebaseStateService.srv
@@ -1,0 +1,5 @@
+bool save_to_disk
+---
+sensor_msgs/Image global_costmap_image
+sensor_msgs/Image local_costmap_image
+sensor_msgs/Image camera_image


### PR DESCRIPTION
This service return the local and global costmaps as image with the global and local plans overlaid. It also returns the last image from the camera. The idea is to use this in `strands_navigation` to get some more info on what happened when the robot failed.

Call the service with `rosservice call /movebase_state_service "save_to_disk: true"` if you want to save the image to `~/.ros/movebase_state_service` or with false if you just want to get the images back as messages.

@bfalacerda Please merge this when you've integrated the service call.
