### PR TITLE
Add run_depend for map server and dwa.

### DIFF
--- a/strands_movebase/package.xml
+++ b/strands_movebase/package.xml
@@ -44,6 +44,8 @@
   <run_depend>tf</run_depend>
   <run_depend>scitos_2d_navigation</run_depend>
   <run_depend>strands_description</run_depend>
+  <run_depend>dwa_local_planner</run_depend>
+  <run_depend>map_server</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
These might also be needed in scitos_2d_navigation.
