### PR TITLE
Starting the state publisher in the chest namespace

### DIFF
--- a/strands_description/launch/strands_state_publisher.launch
+++ b/strands_description/launch/strands_state_publisher.launch
@@ -7,15 +7,19 @@
 
     <!-- Robot -->
     <arg name="urdf_file" default="$(find xacro)/xacro.py '$(find strands_description)/urdf/scitos_chest_camera.xacro'" />
-    <param name="robot_description" command="$(arg urdf_file)" />
+    <arg name="model_file" default="$(find xacro)/xacro.py '$(find strands_description)/urdf/scitos_all_robot_model.xacro'" />
+    <param name="robot_description" command="$(arg model_file)" />
 
-    <!-- Joint state publisher to accumulate joints -->
-    <node name="chest_joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-      <!-- include the pan/tilt unit joint states -->
-      <rosparam param="source_list">[/chest_calibration_publisher/state]</rosparam>
-    </node>
+    <group ns="chest">
+      <param name="robot_description" command="$(arg urdf_file)" />
+      <!-- Joint state publisher to accumulate joints -->
+      <node name="chest_joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+        <!-- include the pan/tilt unit joint states -->
+        <rosparam param="source_list">[/chest_calibration_publisher/state]</rosparam>
+      </node>
 
-    <node name="chest_robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+      <node name="chest_robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+   </group>
 
     <node pkg="calibrate_chest" type="chest_calibration_publisher" name="chest_calibration_publisher" output="screen"/>
 

--- a/strands_description/urdf/scitos_all_robot_model.xacro
+++ b/strands_description/urdf/scitos_all_robot_model.xacro
@@ -7,8 +7,7 @@
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- calibration data -->
-  <!-- <xacro:include filename="$(find scitos_description)/urdf/scitos_calibration.xacro" /> -->
-  <link name="base_link" />
+  <xacro:include filename="$(find scitos_description)/urdf/scitos.xacro" />
 
   <!-- Connect base to chest_xtion_link -->
   <link name="chest_xtion_link">


### PR DESCRIPTION
See https://github.com/strands-project/scitos_common/pull/53

Since we have two state publishers running at the same time, the changes I made in #53 lead to two rivalling tf states for the PTU when it was not at 0,0. As for the robot state publisher, the chest state publisher is now launched in its own namespace `chest` and has its own xarco file in `chest/robot_description`

The global parameter `/robot_description`, initially set in the scitos_description package, is now overridden by the content of the `scitos_all_robot_model.xarco` file. this includes the scitos.xarco from scitos_description and the chest camera model. Sadly, I cannot just include the `scitos.xarco` and `scitos_chest_camera.xarco` because both define `base_link`.

Long story short, the default behaviour is the same as before. If the navigation is started without 3D obstacle avoidance, the robot model set in scito_description is used. if it is started with 3D obstacle avoidance the model including the chest cam is used.
The tf tree seems to be stable again.

@RaresAmbrus or @nilsbore please test.
