### PR TITLE
[calibrate_chest] Allow calibration_server to calibrate and publish at the same time

### DIFF
--- a/calibrate_chest/CMakeLists.txt
+++ b/calibrate_chest/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(calibration_server
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS calibrate_chest chest_calibration_publisher
+install(TARGETS calibrate_chest chest_calibration_publisher calibration_server
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
This is a relatively small fix that doesn't affect any code currently in use. Currently at G4S we were considering adding a task for calibration, this fix would allow the action server to do calibration and publishing with a single command: `calibrate_publish`. Tested on Rosie, works as expected. This also incorporates the bug fix https://github.com/strands-project/strands_movebase/pull/59 .
