### PR TITLE
Debug

### DIFF
--- a/strands_movebase/strands_movebase_params/dwa_planner_ros.yaml
+++ b/strands_movebase/strands_movebase_params/dwa_planner_ros.yaml
@@ -1,17 +1,28 @@
 #see http://ros.org/wiki/dwa_local_planner?distro=groovy for param description
 DWAPlannerROS:
   #default 2.5 -> with this value the robot sometimes gets to close to the wall when leaving a goal position in narrow corridors, causing dwa planner to have problems
-  acc_lim_x: 1.0
+  acc_lim_x: 0.8
+  acc_limit_trans: 0.8
+  acc_lim_y: 0.0 
+  acc_lim_theta: 3.14
   
-  acc_lim_y: 0.0
   
-  #default 3.2
-  acc_lim_th: 2.0
-  
+  min_vel_x: 0.05
+  max_vel_x: 0.55
+  min_trans_vel: 0.05
+  max_trans_vel: 0.55
   min_vel_y: 0.0
   max_vel_y: 0.0
   max_rot_vel: 1.0
-  min_rot_vel: 0.4
+  min_rot_vel: 0.0
+  
+  
+  rot_stopped_vel: 0.4
+  trans_stopped_vel: 0.2
+  
+  vx_samples: 10
+  vy_samples: 1
+  vth_samples: 20
 
   yaw_goal_tolerance: 0.1
   
@@ -23,7 +34,7 @@ DWAPlannerROS:
   latch_xy_goal_tolerance: true
  
 
-  sim_time: 2.1
+  sim_time: 1
   
 
 #cost =  path_distance_bias * (distance to path from the endpoint of the trajectory in meters)  + goal_distance_bias * (distance to local goal from the endpoint of the trajectory in meters)  + occdist_scale * (maximum obstacle cost along the trajectory in obstacle cost (0-254))

--- a/strands_movebase/strands_movebase_params/dwa_planner_ros.yaml
+++ b/strands_movebase/strands_movebase_params/dwa_planner_ros.yaml
@@ -7,46 +7,41 @@ DWAPlannerROS:
   acc_lim_theta: 3.14
   
   
-  min_vel_x: 0.05
+  min_vel_x: 0.00
   max_vel_x: 0.55
   min_trans_vel: 0.05
   max_trans_vel: 0.55
   min_vel_y: 0.0
   max_vel_y: 0.0
   max_rot_vel: 1.0
-  min_rot_vel: 0.0
+  min_rot_vel: 0.4
   
   
-  rot_stopped_vel: 0.4
-  trans_stopped_vel: 0.2
+  rot_stopped_vel: 0.01 #Below what maximum velocity we consider the robot to be stopped in translation", 0.1)
+  trans_stopped_vel: 0.01 #"Below what maximum rotation velocity we consider the robot to be stopped in rotation", 0.1)
+
   
   vx_samples: 10
   vy_samples: 1
   vth_samples: 20
 
+  
   yaw_goal_tolerance: 0.1
-  
   #default:0.1 -> with this value the robot sometimes has troubles achieving the goal, due to low tolerance
-  xy_goal_tolerance: 0.3
-  
-  
+  xy_goal_tolerance: 0.3  
   # if the robot ever reaches the goal xy location it will simply rotate in place, even if it ends up outside the goal tolerance while it is doing so.
   latch_xy_goal_tolerance: true
  
 
-  sim_time: 1
+  sim_time: 1.7
   
-
 #cost =  path_distance_bias * (distance to path from the endpoint of the trajectory in meters)  + goal_distance_bias * (distance to local goal from the endpoint of the trajectory in meters)  + occdist_scale * (maximum obstacle cost along the trajectory in obstacle cost (0-254))
   path_distance_bias: 32.0 #default:32, previous:5
   goal_distance_bias: 24.0 #default:24, previous:9
   occdist_scale: 0.01 #default:0.01
-
   
   oscillation_reset_dist: 0.05
-
+  forward_point_distance: 0.0
 
   prune_plan: true
-
   holonomic_robot: false
-

--- a/strands_movebase/strands_movebase_params/dwa_planner_ros_old.yaml
+++ b/strands_movebase/strands_movebase_params/dwa_planner_ros_old.yaml
@@ -1,0 +1,41 @@
+#see http://ros.org/wiki/dwa_local_planner?distro=groovy for param description
+DWAPlannerROS:
+  #default 2.5 -> with this value the robot sometimes gets to close to the wall when leaving a goal position in narrow corridors, causing dwa planner to have problems
+  acc_lim_x: 1.0
+  
+  acc_lim_y: 0.0
+  
+  #default 3.2
+  acc_lim_th: 2.0
+  
+  min_vel_y: 0.0
+  max_vel_y: 0.0
+  max_rot_vel: 1.0
+  min_rot_vel: 0.4
+
+  yaw_goal_tolerance: 0.1
+  
+  #default:0.1 -> with this value the robot sometimes has troubles achieving the goal, due to low tolerance
+  xy_goal_tolerance: 0.3
+  
+  
+  # if the robot ever reaches the goal xy location it will simply rotate in place, even if it ends up outside the goal tolerance while it is doing so.
+  latch_xy_goal_tolerance: true
+ 
+
+  sim_time: 2.1
+  
+
+#cost =  path_distance_bias * (distance to path from the endpoint of the trajectory in meters)  + goal_distance_bias * (distance to local goal from the endpoint of the trajectory in meters)  + occdist_scale * (maximum obstacle cost along the trajectory in obstacle cost (0-254))
+  path_distance_bias: 32.0 #default:32, previous:5
+  goal_distance_bias: 24.0 #default:24, previous:9
+  occdist_scale: 0.01 #default:0.01
+
+  
+  oscillation_reset_dist: 0.05
+
+
+  prune_plan: true
+
+  holonomic_robot: false
+


### PR DESCRIPTION
Also kept the old params so we can do more structured comparison. 
- acceleration limits changed to the same as used in mira
- min_trans_vel reduced, otherwise with the new acceleration limit the robot wont be able to sample any valid velocities
- decreased rot_stopped_vel and trans_stopped_vel so that the controller is more accurate when checking if the robot has stopped
- increased vx_samples from 3 to 10. since its a differential drive we need more on x to properly control the translational velocity
- decreased vy_samples to 1, as this robot doesnt move in y. In fact this doesn't make a difference in execution, because of the min_vel_y and max_vel_y being 0, it's just for coherence
- put sim_time back to default. with the increased vx_samples the control loop sometimes takes longer that it should so we reduce a bit of the computational burden here. 
- changed forward_point_distance from 0.325 to 0.0, according to https://github.com/strands-project/strands_movebase/issues/62#issuecomment-151539325 
