### PR TITLE
[strands_movebase] Switched subsampling to be loaded as a nodelet

### DIFF
--- a/strands_movebase/CMakeLists.txt
+++ b/strands_movebase/CMakeLists.txt
@@ -4,7 +4,7 @@ project(strands_movebase)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED roscpp sensor_msgs std_msgs pcl_ros tf)
+find_package(catkin REQUIRED roscpp sensor_msgs std_msgs pcl_ros tf nodelet)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -73,6 +73,7 @@ include_directories(
 ## Declare a cpp library
 #add_library(noise_voxel_grid src/noise_voxel_grid.cpp)
 add_library(noise_approximate_voxel_grid src/noise_approximate_voxel_grid.cpp include/strands_movebase/noise_approximate_voxel_grid.h)
+add_library(subsample_cloud_nodelet src/subsample_cloud_nodelet.cpp)
 
 ## Declare a cpp executable
 add_executable(subsample_cloud src/subsample_cloud.cpp)
@@ -86,6 +87,10 @@ add_executable(mirror_floor_points src/mirror_floor_points.cpp)
 
 target_link_libraries(noise_approximate_voxel_grid
   ${PCL_LIBRARIES}
+)
+
+target_link_libraries(subsample_cloud_nodelet
+  ${catkin_LIBRARIES} ${PCL_LIBRARIES} noise_approximate_voxel_grid
 )
 
 target_link_libraries(subsample_cloud

--- a/strands_movebase/CMakeLists.txt
+++ b/strands_movebase/CMakeLists.txt
@@ -135,6 +135,10 @@ install(DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
 
+install(DIRECTORY plugins/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/plugins
+)
+
 install(DIRECTORY strands_movebase_params/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/strands_movebase_params
 )

--- a/strands_movebase/include/strands_movebase/subsample_cloud_nodelet.h
+++ b/strands_movebase/include/strands_movebase/subsample_cloud_nodelet.h
@@ -1,0 +1,25 @@
+#ifndef SUBSAMPLE_CLOUD_NODELET_H
+#define SUBSAMPLE_CLOUD_NODELET_H
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <sensor_msgs/PointCloud2.h>
+
+namespace strands_movebase {
+
+class subsample_cloud_nodelet : public nodelet::Nodelet {
+private:
+    ros::Subscriber sub;
+    ros::Publisher pub;
+    ros::Time time;
+    double resolution;
+    int min_points;
+    int skip_points;
+public:
+    virtual void onInit();
+    void callback(const sensor_msgs::PointCloud2::ConstPtr& msg);
+};
+
+} // movebase_processing
+
+#endif // SUBSAMPLE_CLOUD_NODELET_H

--- a/strands_movebase/launch/obstacles.launch
+++ b/strands_movebase/launch/obstacles.launch
@@ -6,6 +6,7 @@
     <arg name="head_xtion_user" default=""/>
 
     <arg name="chest_xtion_name" default="chest_xtion"/>
+    <arg name="chest_xtion_manager" default="/$(arg chest_xtion_name)/$(arg chest_xtion_name)_nodelet_manager"/>
     <arg name="z_stair_threshold" default="0.12"/>
 
     <arg name="with_head_xtion" default="false"/>
@@ -20,8 +21,20 @@
     <machine name="$(arg head_xtion_machine)" address="$(arg head_xtion_machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg head_xtion_user)" default="false"/>
 
     <!-- This node downsamples cloud and removes voxels with too few points in them -->
+    <!-- This is commented out in favour of the more efficient nodelet version below -->
+    <!--
     <node pkg="strands_movebase" type="subsample_cloud" name="subsample_cloud" output="screen" machine="$(arg chest_xtion_machine)">
         <param name="input" value="$(arg chest_xtion_name)/depth/points"/>
+        <param name="output" value="/move_base/points_subsampled"/>
+        <param name="resolution" value="$(arg resolution)"/>
+        <param name="min_points" value="$(arg min_points)"/>
+        <param name="skip_points" value="$(arg skip_points)"/>
+    </node>
+    -->
+
+    <!-- The machine tag is not needed here since it is loaded into the nodelet manager of the chest_xtion driver -->
+    <node pkg="nodelet" type="nodelet" name="subsample_cloud_nodelet" args="load strands_movebase/subsample_cloud_nodelet $(arg chest_xtion_manager)" output="screen">
+        <param name="input" value="/$(arg chest_xtion_name)/depth/points"/>
         <param name="output" value="/move_base/points_subsampled"/>
         <param name="resolution" value="$(arg resolution)"/>
         <param name="min_points" value="$(arg min_points)"/>

--- a/strands_movebase/package.xml
+++ b/strands_movebase/package.xml
@@ -36,6 +36,7 @@
   <build_depend>pcl_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>nodelet</build_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
@@ -48,13 +49,10 @@
   <run_depend>map_server</run_depend>
   <run_depend>movebase_state_service</run_depend>
   <run_depend>strands_navfn</run_depend>
+  <run_depend>nodelet</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
+    <nodelet plugin="${prefix}/plugins/nodelet_plugins.xml" />
   </export>
 </package>

--- a/strands_movebase/plugins/nodelet_plugins.xml
+++ b/strands_movebase/plugins/nodelet_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libsubsample_cloud_nodelet">
+  <class name="strands_movebase/subsample_cloud_nodelet" type="strands_movebase::subsample_cloud_nodelet" base_class_type="nodelet::Nodelet">
+  <description>
+  This is my nodelet.
+  </description>
+  </class>
+</library>

--- a/strands_movebase/src/subsample_cloud_nodelet.cpp
+++ b/strands_movebase/src/subsample_cloud_nodelet.cpp
@@ -1,0 +1,81 @@
+#include "strands_movebase/subsample_cloud_nodelet.h"
+
+// this should really be in the implementation (.cpp file)
+#include <pluginlib/class_list_macros.h>
+
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/filters/statistical_outlier_removal.h>
+#include <boost/thread/thread.hpp>
+#include "strands_movebase/noise_approximate_voxel_grid.h"
+
+// watch the capitalization carefully
+PLUGINLIB_EXPORT_CLASS(strands_movebase::subsample_cloud_nodelet, nodelet::Nodelet)
+
+namespace strands_movebase {
+
+void subsample_cloud_nodelet::onInit()
+{
+    NODELET_INFO("Initializing subsample_cloud nodelet...");
+
+    ros::NodeHandle nh = getNodeHandle();
+    ros::NodeHandle pn = getPrivateNodeHandle();
+
+    // topic of input cloud
+    if (!pn.hasParam("input")) {
+        ROS_ERROR("Could not find parameter input.");
+    }
+    std::string input;
+    pn.getParam("input", input);
+    NODELET_INFO("With input %s", input.c_str());
+
+    // topic of output cloud
+    if (!pn.hasParam("output")) {
+        ROS_ERROR("Could not find parameter output.");
+    }
+    std::string output;
+    pn.getParam("output", output);
+    NODELET_INFO("And output %s", output.c_str());
+
+    pn.param<double>("resolution", resolution, 0.05);
+    pn.param<int>("min_points", min_points, 5);
+    pn.param<int>("skip_points", skip_points, 20);
+
+    time = ros::Time::now();
+
+    sub = nh.subscribe(input, 1, &subsample_cloud_nodelet::callback, this);
+    pub = nh.advertise<sensor_msgs::PointCloud2>(output, 1);
+
+    /*ros::Rate rate(5); // updating at 5 hz, slightly faster than move_base
+    while (n.ok()) {
+        rate.sleep();
+        ros::spinOnce();
+    }*/
+}
+
+void subsample_cloud_nodelet::callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
+{
+    ros::Time new_time = ros::Time::now();
+    if ((new_time - time).toSec() < 0.2) {
+        return;
+    }
+    time = new_time;
+
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    pcl::fromROSMsg(*msg, *cloud);
+    pcl::PointCloud<pcl::PointXYZ> voxel_cloud;
+
+    noise_approximate_voxel_grid sor(min_points, skip_points); // a bit faster than nvg, not as accurate
+    sor.setInputCloud(cloud);
+    sor.setLeafSize(resolution, resolution, resolution);
+    sor.filter(voxel_cloud);
+
+    sensor_msgs::PointCloud2 msg_cloud;
+    pcl::toROSMsg(voxel_cloud, msg_cloud);
+    msg_cloud.header = msg->header;
+
+    pub.publish(msg_cloud);
+}
+
+} // movebase_processing

--- a/strands_movebase/src/subsample_cloud_nodelet.cpp
+++ b/strands_movebase/src/subsample_cloud_nodelet.cpp
@@ -46,18 +46,13 @@ void subsample_cloud_nodelet::onInit()
 
     sub = nh.subscribe(input, 1, &subsample_cloud_nodelet::callback, this);
     pub = nh.advertise<sensor_msgs::PointCloud2>(output, 1);
-
-    /*ros::Rate rate(5); // updating at 5 hz, slightly faster than move_base
-    while (n.ok()) {
-        rate.sleep();
-        ros::spinOnce();
-    }*/
 }
 
 void subsample_cloud_nodelet::callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
 {
+    // this will give us a rate of ~5hz
     ros::Time new_time = ros::Time::now();
-    if ((new_time - time).toSec() < 0.2) {
+    if ((new_time - time).toSec() < 0.18) {
         return;
     }
     time = new_time;


### PR DESCRIPTION
This adds the `subsample_cloud_nodelet`, which is loaded by the `chest_xtion_nodelet_manager`. This means that the `/chest_xtion/depth/points` does not have to be serialized and copied over message transport, leading to some speedups. On my computer, `nodelet` (the `chest_xtion` driver) takes a bit more than 40% CPU and the `subsample_cloud` node about 22% CPU. With the change, (with the `subsample_cloud_nodelet` run as part of `nodelet`), `nodelet` still only takes about 45% CPU. So it seems worthy of merging.
