### PR TITLE
proper value for aggressive costmap reset distance

### DIFF
--- a/strands_movebase/strands_movebase_params/move_base_params.yaml
+++ b/strands_movebase/strands_movebase_params/move_base_params.yaml
@@ -14,5 +14,5 @@ conservative_reset:
 
 aggressive_reset:
   layer_names: ["obstacle_layer"]
-  reset_distance: 0.0
+  reset_distance: 0.38 #distance from rotation centre to tail (0.32m) + 6cm slack
   


### PR DESCRIPTION
I think the current value is an accident waiting to happen:
1. robot passes next to a wheelchair and gets stuck shortly after
2. current aggressive costmap reset clear everything the robot doesn't see, including the chair
3. robot can now happily rotate and crash into the wheelchair

So, this version takes into account the robot's tail when clearing the costmaps. I was reminded of this param due to https://github.com/strands-project/strands_movebase/issues/62#issuecomment-154044167, it might be that with this the robot isn't able to slightly move anymore, and move_base won't get stuck in the infinite dwa fails - costmap cleared - dwa moves just a bit - dwa fails loop anymore. Regardless, I think this should be merged, for safety issues
